### PR TITLE
secret-distributor: Use stringData

### DIFF
--- a/charts/secret-distributor/Chart.yaml
+++ b/charts/secret-distributor/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: secret-distributor
-description: A Helm chart for Kubernetes
+description: A simple chart which only aims to distribute Secret resource, intended to be used with helm-secrets
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: 1.0.0

--- a/charts/secret-distributor/templates/secret.yaml
+++ b/charts/secret-distributor/templates/secret.yaml
@@ -15,8 +15,6 @@ metadata:
     {{- toYaml $.Values.secret.annotations | nindent 4 }}
   {{- end }}
 type: {{ $.Values.secret.type | default "Opaque" }}
-data:
-  {{- range $k, $v := $.Values.secret.data }}
-  {{ $k }}: {{ $v | b64enc }}
-  {{- end }}
+stringData:
+  {{- toYaml $.Values.secret.data | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
Use `stringData` instead of `data` key in generated Secret so that we can see the actual diff with helm-diff like below:

```diff
$ helmfile diff --show-secrets
Building dependency release=secret-distributor, chart=/Users/shu/workspaces/my/helm-charts/charts/secret-distributor
Comparing release=secret-distributor, chart=/Users/shu/workspaces/my/helm-charts/charts/secret-distributor
secret-distributor, orange, Secret (v1) has changed:
  # Source: secret-distributor/templates/secret.yaml
  apiVersion: v1
  kind: Secret
  metadata:
    namespace: secret-distributor
    name: orange
    labels:
      helm.sh/chart: secret-distributor-0.4.0
      app.kubernetes.io/name: secret-distributor
      app.kubernetes.io/instance: secret-distributor
      app.kubernetes.io/version: "1.0.0"
      app.kubernetes.io/managed-by: Helm
  type: Opaque
  stringData:
-   abc: apple
+   abc: apple juice
    def: |
      This is a secret
+     hello
      banna
```